### PR TITLE
chores(deps): bumps `block-explorer-rpc-cosmos v1.0.2` & `evm-block-explorer-rpc-cosmos` v1.0.2

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,8 +4,8 @@ go 1.22.1
 
 require (
 	cosmossdk.io/errors v1.0.1
-	github.com/bcdevtools/block-explorer-rpc-cosmos v1.0.1
-	github.com/bcdevtools/evm-block-explorer-rpc-cosmos v1.0.1
+	github.com/bcdevtools/block-explorer-rpc-cosmos v1.0.2
+	github.com/bcdevtools/evm-block-explorer-rpc-cosmos v1.0.2
 	github.com/cosmos/cosmos-sdk v0.46.15
 	github.com/cosmos/ibc-go/v6 v6.2.1
 	github.com/dymensionxyz/dymension-rdk v1.2.0-beta

--- a/go.sum
+++ b/go.sum
@@ -293,10 +293,10 @@ github.com/aws/aws-sdk-go-v2/service/route53 v1.1.1/go.mod h1:rLiOUrPLW/Er5kRcQ7
 github.com/aws/aws-sdk-go-v2/service/sso v1.1.1/go.mod h1:SuZJxklHxLAXgLTc1iFXbEWkXs7QRTQpCLGaKIprQW0=
 github.com/aws/aws-sdk-go-v2/service/sts v1.1.1/go.mod h1:Wi0EBZwiz/K44YliU0EKxqTCJGUfYTWXrrBwkq736bM=
 github.com/aws/smithy-go v1.1.0/go.mod h1:EzMw8dbp/YJL4A5/sbhGddag+NPT7q084agLbB9LgIw=
-github.com/bcdevtools/block-explorer-rpc-cosmos v1.0.1 h1:/mkYfjhJSQr71mJUFbOoyRvykSUj6TgwB9m9sKtqtOI=
-github.com/bcdevtools/block-explorer-rpc-cosmos v1.0.1/go.mod h1:AWXHI5ICXK4wB+A59dNddzq5Xdc1wtQDRiIXfMw8cwc=
-github.com/bcdevtools/evm-block-explorer-rpc-cosmos v1.0.1 h1:O0sWD/Hky5wUWsWMhmkifDUj2Qhjyu3pZH1/C7n0Kqg=
-github.com/bcdevtools/evm-block-explorer-rpc-cosmos v1.0.1/go.mod h1:IN6s8jCudUJh8E8Mm3iNqITL05Wcj4+PJvfRUUQnipI=
+github.com/bcdevtools/block-explorer-rpc-cosmos v1.0.2 h1:184TNBIvyozlPy12CPgXvmY/YcWN+ur2m0qA5vlHMQY=
+github.com/bcdevtools/block-explorer-rpc-cosmos v1.0.2/go.mod h1:AWXHI5ICXK4wB+A59dNddzq5Xdc1wtQDRiIXfMw8cwc=
+github.com/bcdevtools/evm-block-explorer-rpc-cosmos v1.0.2 h1:QP6Wv0knYlrGN084vhPlpGnSgvtIbNsZBSmXw0HTJJw=
+github.com/bcdevtools/evm-block-explorer-rpc-cosmos v1.0.2/go.mod h1:8tZyNxXbNamM9LbQvAD1FrLZIlMx8JUEpt7W9nywiJs=
 github.com/benbjohnson/clock v1.1.0/go.mod h1:J11/hYXuz8f4ySSvYwY0FKfm+ezbsZBKZxNJlLklBHA=
 github.com/benbjohnson/clock v1.3.0/go.mod h1:J11/hYXuz8f4ySSvYwY0FKfm+ezbsZBKZxNJlLklBHA=
 github.com/benbjohnson/clock v1.3.5 h1:VvXlSJBzZpA/zum6Sj74hxwYI2DIxRWuNIoXAzHZz5o=


### PR DESCRIPTION
This PR update version for 2 dependencies:
- [github.com/bcdevtools/block-explorer-rpc-cosmos v1.0.1 → v1.0.2](https://github.com/bcdevtools/block-explorer-rpc-cosmos/compare/v1.0.1...v1.0.2)
- [github.com/bcdevtools/evm-block-explorer-rpc-cosmos v1.0.1 → v1.0.2](https://github.com/bcdevtools/evm-block-explorer-rpc-cosmos/compare/v1.0.1...v1.0.2)

Content:
- Returns message signer.
- Limit number of input contracts for endpoint getting ERC-20 balance.