### PR TITLE
fix(deps): bumps `block-explorer-rpc-cosmos v1.0.3` & `evm-block-explorer-rpc-cosmos` v1.0.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,17 +43,17 @@ Templates for Unreleased:
 
 ## Unreleased
 
-#### Features
+### Features
 
-#### Improvements
+### Improvements
 
-#### Bug Fixes
+### Bug Fixes
 
-#### Client Breaking
+### Client Breaking
 
-#### API Breaking
+### API Breaking
 
-#### State Machine Breaking
+### State Machine Breaking
 
 -->
 
@@ -61,8 +61,10 @@ Templates for Unreleased:
 
 ## Unreleased
 
-#### Improvements
+### Improvements
+
 - (deps) [#138](https://github.com/dymensionxyz/rollapp-evm/issues/138) Bumps `block-explorer-rpc-cosmos v1.0.2` & `evm-block-explorer-rpc-cosmos` v1.0.2
 
-#### Bug Fixes
+### Bug Fixes
+
 - (deps) [#142](https://github.com/dymensionxyz/rollapp-evm/issues/142) Bumps `block-explorer-rpc-cosmos v1.0.3` & `evm-block-explorer-rpc-cosmos` v1.0.3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,68 @@
+<!--
+Guiding Principles:
+
+Changelogs are for humans, not machines.
+There should be an entry for every single version.
+The same types of changes should be grouped.
+Versions and sections should be linkable.
+The latest version comes first.
+The release date of each version is displayed.
+Mention whether you follow Semantic Versioning.
+
+Usage:
+
+Change log entries are to be added to the Unreleased section under the
+appropriate stanza (see below). Each entry should ideally include a tag and
+the GitHub issue reference in the following format:
+
+* (<tag>) \#<issue-number> message
+
+Tag must include `sql` if having any changes relate to schema
+
+The issue numbers will later be link-ified during the release process,
+so you do not have to worry about including a link manually, but you can if you wish.
+
+Types of changes (Stanzas):
+
+"Features" for new features.
+"Improvements" for changes in existing functionality.
+"Deprecated" for soon-to-be removed features.
+"Bug Fixes" for any bug fixes.
+"Client Breaking" for breaking CLI commands and REST routes used by end-users.
+"API Breaking" for breaking exported APIs used by developers building on SDK.
+"State Machine Breaking" for any changes that result in a different AppState
+given same genesisState and txList.
+
+If any PR belong to multiple types of change, reference it into all types with only ticket id, no need description (convention)
+
+Ref: https://keepachangelog.com/en/1.0.0/
+-->
+
+<!--
+Templates for Unreleased:
+
+## Unreleased
+
+#### Features
+
+#### Improvements
+
+#### Bug Fixes
+
+#### Client Breaking
+
+#### API Breaking
+
+#### State Machine Breaking
+
+-->
+
+# Changelog
+
+## Unreleased
+
+#### Improvements
+- (deps) [#138](https://github.com/dymensionxyz/rollapp-evm/issues/138) Bumps `block-explorer-rpc-cosmos v1.0.2` & `evm-block-explorer-rpc-cosmos` v1.0.2
+
+#### Bug Fixes
+- (deps) [#142](https://github.com/dymensionxyz/rollapp-evm/issues/142) Bumps `block-explorer-rpc-cosmos v1.0.3` & `evm-block-explorer-rpc-cosmos` v1.0.3

--- a/go.mod
+++ b/go.mod
@@ -4,8 +4,8 @@ go 1.22.1
 
 require (
 	cosmossdk.io/errors v1.0.1
-	github.com/bcdevtools/block-explorer-rpc-cosmos v1.0.2
-	github.com/bcdevtools/evm-block-explorer-rpc-cosmos v1.0.2
+	github.com/bcdevtools/block-explorer-rpc-cosmos v1.0.3
+	github.com/bcdevtools/evm-block-explorer-rpc-cosmos v1.0.3
 	github.com/cosmos/cosmos-sdk v0.46.15
 	github.com/cosmos/ibc-go/v6 v6.2.1
 	github.com/dymensionxyz/dymension-rdk v1.2.0-beta

--- a/go.sum
+++ b/go.sum
@@ -293,10 +293,10 @@ github.com/aws/aws-sdk-go-v2/service/route53 v1.1.1/go.mod h1:rLiOUrPLW/Er5kRcQ7
 github.com/aws/aws-sdk-go-v2/service/sso v1.1.1/go.mod h1:SuZJxklHxLAXgLTc1iFXbEWkXs7QRTQpCLGaKIprQW0=
 github.com/aws/aws-sdk-go-v2/service/sts v1.1.1/go.mod h1:Wi0EBZwiz/K44YliU0EKxqTCJGUfYTWXrrBwkq736bM=
 github.com/aws/smithy-go v1.1.0/go.mod h1:EzMw8dbp/YJL4A5/sbhGddag+NPT7q084agLbB9LgIw=
-github.com/bcdevtools/block-explorer-rpc-cosmos v1.0.2 h1:184TNBIvyozlPy12CPgXvmY/YcWN+ur2m0qA5vlHMQY=
-github.com/bcdevtools/block-explorer-rpc-cosmos v1.0.2/go.mod h1:AWXHI5ICXK4wB+A59dNddzq5Xdc1wtQDRiIXfMw8cwc=
-github.com/bcdevtools/evm-block-explorer-rpc-cosmos v1.0.2 h1:QP6Wv0knYlrGN084vhPlpGnSgvtIbNsZBSmXw0HTJJw=
-github.com/bcdevtools/evm-block-explorer-rpc-cosmos v1.0.2/go.mod h1:8tZyNxXbNamM9LbQvAD1FrLZIlMx8JUEpt7W9nywiJs=
+github.com/bcdevtools/block-explorer-rpc-cosmos v1.0.3 h1:TBC6STStcirdPrUGvsJf4Q07x8lka8Fz24OV5NHFBdA=
+github.com/bcdevtools/block-explorer-rpc-cosmos v1.0.3/go.mod h1:AWXHI5ICXK4wB+A59dNddzq5Xdc1wtQDRiIXfMw8cwc=
+github.com/bcdevtools/evm-block-explorer-rpc-cosmos v1.0.3 h1:wF1kVsk1UD7aBnC7Rj2AwBct+8eIi/a0NqROmCckJsI=
+github.com/bcdevtools/evm-block-explorer-rpc-cosmos v1.0.3/go.mod h1:FDVflbDiJrWujpriItn6Y9eg6XZN4RdKGO1vnL8Z6V0=
 github.com/benbjohnson/clock v1.1.0/go.mod h1:J11/hYXuz8f4ySSvYwY0FKfm+ezbsZBKZxNJlLklBHA=
 github.com/benbjohnson/clock v1.3.0/go.mod h1:J11/hYXuz8f4ySSvYwY0FKfm+ezbsZBKZxNJlLklBHA=
 github.com/benbjohnson/clock v1.3.5 h1:VvXlSJBzZpA/zum6Sj74hxwYI2DIxRWuNIoXAzHZz5o=


### PR DESCRIPTION
This PR update version for 2 dependencies:
- [github.com/bcdevtools/block-explorer-rpc-cosmos v1.0.2 → v1.0.3](https://github.com/bcdevtools/block-explorer-rpc-cosmos/compare/v1.0.2...v1.0.3)
- [github.com/bcdevtools/evm-block-explorer-rpc-cosmos v1.0.2 → v1.0.3](https://github.com/bcdevtools/evm-block-explorer-rpc-cosmos/compare/v1.0.2...v1.0.3)

Content:
- Fix a RPC handler crash due to invalid handling of EVM receipt.
- Add new RPC endpoint `be_getLatestBlockNumber` for performance reason.