### PR TITLE
chores(deps): bumps `block-explorer-rpc-cosmos v1.1.0` & `evm-block-explorer-rpc-cosmos v1.1.0`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,8 +63,9 @@ Templates for Unreleased:
 
 ### Improvements
 
-- (deps) [#138](https://github.com/dymensionxyz/rollapp-evm/issues/138) Bumps `block-explorer-rpc-cosmos v1.0.2` & `evm-block-explorer-rpc-cosmos` v1.0.2
+- (deps) [#138](https://github.com/dymensionxyz/rollapp-evm/issues/138) Bumps `block-explorer-rpc-cosmos v1.0.2` & `evm-block-explorer-rpc-cosmos v1.0.2`
+- (deps) [#151](https://github.com/dymensionxyz/rollapp-evm/issues/151) Bumps `block-explorer-rpc-cosmos v1.0.2` & `evm-block-explorer-rpc-cosmos v1.1.0`
 
 ### Bug Fixes
 
-- (deps) [#142](https://github.com/dymensionxyz/rollapp-evm/issues/142) Bumps `block-explorer-rpc-cosmos v1.0.3` & `evm-block-explorer-rpc-cosmos` v1.0.3
+- (deps) [#142](https://github.com/dymensionxyz/rollapp-evm/issues/142) Bumps `block-explorer-rpc-cosmos v1.0.3` & `evm-block-explorer-rpc-cosmos v1.0.3`

--- a/go.mod
+++ b/go.mod
@@ -4,8 +4,8 @@ go 1.22.1
 
 require (
 	cosmossdk.io/errors v1.0.1
-	github.com/bcdevtools/block-explorer-rpc-cosmos v1.0.3
-	github.com/bcdevtools/evm-block-explorer-rpc-cosmos v1.0.3
+	github.com/bcdevtools/block-explorer-rpc-cosmos v1.1.0
+	github.com/bcdevtools/evm-block-explorer-rpc-cosmos v1.1.0
 	github.com/cosmos/cosmos-sdk v0.46.16
 	github.com/cosmos/ibc-go/v6 v6.2.1
 	github.com/dymensionxyz/dymension-rdk v1.2.0-beta.0.20240408142908-4bef39f8b16c

--- a/go.sum
+++ b/go.sum
@@ -295,10 +295,10 @@ github.com/aws/aws-sdk-go-v2/service/route53 v1.1.1/go.mod h1:rLiOUrPLW/Er5kRcQ7
 github.com/aws/aws-sdk-go-v2/service/sso v1.1.1/go.mod h1:SuZJxklHxLAXgLTc1iFXbEWkXs7QRTQpCLGaKIprQW0=
 github.com/aws/aws-sdk-go-v2/service/sts v1.1.1/go.mod h1:Wi0EBZwiz/K44YliU0EKxqTCJGUfYTWXrrBwkq736bM=
 github.com/aws/smithy-go v1.1.0/go.mod h1:EzMw8dbp/YJL4A5/sbhGddag+NPT7q084agLbB9LgIw=
-github.com/bcdevtools/block-explorer-rpc-cosmos v1.0.3 h1:TBC6STStcirdPrUGvsJf4Q07x8lka8Fz24OV5NHFBdA=
-github.com/bcdevtools/block-explorer-rpc-cosmos v1.0.3/go.mod h1:AWXHI5ICXK4wB+A59dNddzq5Xdc1wtQDRiIXfMw8cwc=
-github.com/bcdevtools/evm-block-explorer-rpc-cosmos v1.0.3 h1:wF1kVsk1UD7aBnC7Rj2AwBct+8eIi/a0NqROmCckJsI=
-github.com/bcdevtools/evm-block-explorer-rpc-cosmos v1.0.3/go.mod h1:FDVflbDiJrWujpriItn6Y9eg6XZN4RdKGO1vnL8Z6V0=
+github.com/bcdevtools/block-explorer-rpc-cosmos v1.1.0 h1:eSnGgASQu4M0buXP9O3PH5sIpMZyDXYlQuwuZzo2mhY=
+github.com/bcdevtools/block-explorer-rpc-cosmos v1.1.0/go.mod h1:AWXHI5ICXK4wB+A59dNddzq5Xdc1wtQDRiIXfMw8cwc=
+github.com/bcdevtools/evm-block-explorer-rpc-cosmos v1.1.0 h1:KMFoLpyH/XqOIn0yCA5TDeipbRRSDS0VDUSL2Mf3KL0=
+github.com/bcdevtools/evm-block-explorer-rpc-cosmos v1.1.0/go.mod h1:Lf5324n7/VNjCS8MV4/14rtlnUOGZ2+Z04VXOSSjBhs=
 github.com/benbjohnson/clock v1.1.0/go.mod h1:J11/hYXuz8f4ySSvYwY0FKfm+ezbsZBKZxNJlLklBHA=
 github.com/benbjohnson/clock v1.3.0/go.mod h1:J11/hYXuz8f4ySSvYwY0FKfm+ezbsZBKZxNJlLklBHA=
 github.com/benbjohnson/clock v1.3.5 h1:VvXlSJBzZpA/zum6Sj74hxwYI2DIxRWuNIoXAzHZz5o=


### PR DESCRIPTION
This PR update version for 2 dependencies:
- [github.com/bcdevtools/block-explorer-rpc-cosmos v1.0.3 → v1.1.0](https://github.com/bcdevtools/block-explorer-rpc-cosmos/compare/v1.0.3...v1.1.0)
- [github.com/bcdevtools/evm-block-explorer-rpc-cosmos v1.0.3 → v1.1.0](https://github.com/bcdevtools/evm-block-explorer-rpc-cosmos/compare/v1.0.3...v1.1.0)

Content:
- Fix issue token contract balance of address not tracked.
- Response additional details of Evm tx for indexer.
- Response additional field proto-type for account detection.