### PR TITLE
chores(deps): bumps `block-explorer-rpc-cosmos v1.1.2`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,7 +64,8 @@ Templates for Unreleased:
 ### Improvements
 
 - (deps) [#138](https://github.com/dymensionxyz/rollapp-evm/issues/138) Bumps `block-explorer-rpc-cosmos v1.0.2` & `evm-block-explorer-rpc-cosmos v1.0.2`
-- (deps) [#151](https://github.com/dymensionxyz/rollapp-evm/issues/151) Bumps `block-explorer-rpc-cosmos v1.0.2` & `evm-block-explorer-rpc-cosmos v1.1.0`
+- (deps) [#151](https://github.com/dymensionxyz/rollapp-evm/issues/151) Bumps `block-explorer-rpc-cosmos v1.1.0` & `evm-block-explorer-rpc-cosmos v1.1.0`
+- (deps) [#167](https://github.com/dymensionxyz/rollapp-evm/issues/167) Bumps `block-explorer-rpc-cosmos v1.1.2`
 
 ### Bug Fixes
 

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.22.1
 
 require (
 	cosmossdk.io/errors v1.0.1
-	github.com/bcdevtools/block-explorer-rpc-cosmos v1.1.0
+	github.com/bcdevtools/block-explorer-rpc-cosmos v1.1.2
 	github.com/bcdevtools/evm-block-explorer-rpc-cosmos v1.1.0
 	github.com/cosmos/cosmos-sdk v0.46.16
 	github.com/cosmos/ibc-go/v6 v6.2.1

--- a/go.sum
+++ b/go.sum
@@ -295,8 +295,8 @@ github.com/aws/aws-sdk-go-v2/service/route53 v1.1.1/go.mod h1:rLiOUrPLW/Er5kRcQ7
 github.com/aws/aws-sdk-go-v2/service/sso v1.1.1/go.mod h1:SuZJxklHxLAXgLTc1iFXbEWkXs7QRTQpCLGaKIprQW0=
 github.com/aws/aws-sdk-go-v2/service/sts v1.1.1/go.mod h1:Wi0EBZwiz/K44YliU0EKxqTCJGUfYTWXrrBwkq736bM=
 github.com/aws/smithy-go v1.1.0/go.mod h1:EzMw8dbp/YJL4A5/sbhGddag+NPT7q084agLbB9LgIw=
-github.com/bcdevtools/block-explorer-rpc-cosmos v1.1.0 h1:eSnGgASQu4M0buXP9O3PH5sIpMZyDXYlQuwuZzo2mhY=
-github.com/bcdevtools/block-explorer-rpc-cosmos v1.1.0/go.mod h1:AWXHI5ICXK4wB+A59dNddzq5Xdc1wtQDRiIXfMw8cwc=
+github.com/bcdevtools/block-explorer-rpc-cosmos v1.1.2 h1:XS/OOOWXaAvFQ06qzrZStCkayQ8ZOEJM3zE6Pp/rOn4=
+github.com/bcdevtools/block-explorer-rpc-cosmos v1.1.2/go.mod h1:AWXHI5ICXK4wB+A59dNddzq5Xdc1wtQDRiIXfMw8cwc=
 github.com/bcdevtools/evm-block-explorer-rpc-cosmos v1.1.0 h1:KMFoLpyH/XqOIn0yCA5TDeipbRRSDS0VDUSL2Mf3KL0=
 github.com/bcdevtools/evm-block-explorer-rpc-cosmos v1.1.0/go.mod h1:Lf5324n7/VNjCS8MV4/14rtlnUOGZ2+Z04VXOSSjBhs=
 github.com/benbjohnson/clock v1.1.0/go.mod h1:J11/hYXuz8f4ySSvYwY0FKfm+ezbsZBKZxNJlLklBHA=


### PR DESCRIPTION
This PR update version for 1 dependency:
- [github.com/bcdevtools/block-explorer-rpc-cosmos v1.1.0 → v1.1.2](https://github.com/bcdevtools/block-explorer-rpc-cosmos/compare/v1.1.0...v1.1.2)

Content:
- Improve content returns for indexer.
- Prevent crashing the entire method when batch query blocks for indexing.
