### PR TITLE
chores(deps): bump be-rpc libs

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,8 +4,8 @@ go 1.22.2
 
 require (
 	cosmossdk.io/errors v1.0.1
-	github.com/bcdevtools/block-explorer-rpc-cosmos v1.1.0
-	github.com/bcdevtools/evm-block-explorer-rpc-cosmos v1.1.0
+	github.com/bcdevtools/block-explorer-rpc-cosmos v1.1.4
+	github.com/bcdevtools/evm-block-explorer-rpc-cosmos v1.1.2
 	github.com/cosmos/cosmos-sdk v0.46.16
 	github.com/cosmos/ibc-go/v6 v6.2.1
 	github.com/dymensionxyz/dymension-rdk v1.6.0

--- a/go.sum
+++ b/go.sum
@@ -295,10 +295,10 @@ github.com/aws/aws-sdk-go-v2/service/route53 v1.1.1/go.mod h1:rLiOUrPLW/Er5kRcQ7
 github.com/aws/aws-sdk-go-v2/service/sso v1.1.1/go.mod h1:SuZJxklHxLAXgLTc1iFXbEWkXs7QRTQpCLGaKIprQW0=
 github.com/aws/aws-sdk-go-v2/service/sts v1.1.1/go.mod h1:Wi0EBZwiz/K44YliU0EKxqTCJGUfYTWXrrBwkq736bM=
 github.com/aws/smithy-go v1.1.0/go.mod h1:EzMw8dbp/YJL4A5/sbhGddag+NPT7q084agLbB9LgIw=
-github.com/bcdevtools/block-explorer-rpc-cosmos v1.1.0 h1:eSnGgASQu4M0buXP9O3PH5sIpMZyDXYlQuwuZzo2mhY=
-github.com/bcdevtools/block-explorer-rpc-cosmos v1.1.0/go.mod h1:AWXHI5ICXK4wB+A59dNddzq5Xdc1wtQDRiIXfMw8cwc=
-github.com/bcdevtools/evm-block-explorer-rpc-cosmos v1.1.0 h1:KMFoLpyH/XqOIn0yCA5TDeipbRRSDS0VDUSL2Mf3KL0=
-github.com/bcdevtools/evm-block-explorer-rpc-cosmos v1.1.0/go.mod h1:Lf5324n7/VNjCS8MV4/14rtlnUOGZ2+Z04VXOSSjBhs=
+github.com/bcdevtools/block-explorer-rpc-cosmos v1.1.4 h1:RvGu0kR6VTImQYF0bhjWcyJltDFj/gg9tjCln2++sgo=
+github.com/bcdevtools/block-explorer-rpc-cosmos v1.1.4/go.mod h1:AWXHI5ICXK4wB+A59dNddzq5Xdc1wtQDRiIXfMw8cwc=
+github.com/bcdevtools/evm-block-explorer-rpc-cosmos v1.1.2 h1:EOsjOIaqlqgIz1V2zpIf4Av2OkPZsbGY2WQbhFTorr0=
+github.com/bcdevtools/evm-block-explorer-rpc-cosmos v1.1.2/go.mod h1:krYTATKzetOs629qD/rHKaBxRc4eDmNgI9KmrEv5aXQ=
 github.com/benbjohnson/clock v1.1.0/go.mod h1:J11/hYXuz8f4ySSvYwY0FKfm+ezbsZBKZxNJlLklBHA=
 github.com/benbjohnson/clock v1.3.0/go.mod h1:J11/hYXuz8f4ySSvYwY0FKfm+ezbsZBKZxNJlLklBHA=
 github.com/benbjohnson/clock v1.3.5 h1:VvXlSJBzZpA/zum6Sj74hxwYI2DIxRWuNIoXAzHZz5o=


### PR DESCRIPTION
This update contains fix for
- RPC crash
- Validator list
- Some additional tx details

https://github.com/bcdevtools/block-explorer-rpc-cosmos/compare/v1.1.0...v1.1.4
https://github.com/bcdevtools/evm-block-explorer-rpc-cosmos/compare/v1.1.0...v1.1.2