### PR TITLE
chores(deps): bump be-rpc libs

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.22.2
 
 require (
 	cosmossdk.io/errors v1.0.1
-	github.com/bcdevtools/block-explorer-rpc-cosmos v1.1.6
+	github.com/bcdevtools/block-explorer-rpc-cosmos v1.1.7
 	github.com/bcdevtools/evm-block-explorer-rpc-cosmos v1.1.2
 	github.com/cosmos/cosmos-sdk v0.46.16
 	github.com/cosmos/ibc-go/v6 v6.2.1

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.22.2
 
 require (
 	cosmossdk.io/errors v1.0.1
-	github.com/bcdevtools/block-explorer-rpc-cosmos v1.2.2
+	github.com/bcdevtools/block-explorer-rpc-cosmos v1.2.3
 	github.com/bcdevtools/evm-block-explorer-rpc-cosmos v1.1.3
 	github.com/cosmos/cosmos-sdk v0.46.16
 	github.com/cosmos/ibc-go/v6 v6.2.1

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.22.2
 
 require (
 	cosmossdk.io/errors v1.0.1
-	github.com/bcdevtools/block-explorer-rpc-cosmos v1.1.7
+	github.com/bcdevtools/block-explorer-rpc-cosmos v1.2.1
 	github.com/bcdevtools/evm-block-explorer-rpc-cosmos v1.1.3
 	github.com/cosmos/cosmos-sdk v0.46.16
 	github.com/cosmos/ibc-go/v6 v6.2.1

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.22.2
 
 require (
 	cosmossdk.io/errors v1.0.1
-	github.com/bcdevtools/block-explorer-rpc-cosmos v1.2.1
+	github.com/bcdevtools/block-explorer-rpc-cosmos v1.2.2
 	github.com/bcdevtools/evm-block-explorer-rpc-cosmos v1.1.3
 	github.com/cosmos/cosmos-sdk v0.46.16
 	github.com/cosmos/ibc-go/v6 v6.2.1

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.22.2
 require (
 	cosmossdk.io/errors v1.0.1
 	github.com/bcdevtools/block-explorer-rpc-cosmos v1.1.7
-	github.com/bcdevtools/evm-block-explorer-rpc-cosmos v1.1.2
+	github.com/bcdevtools/evm-block-explorer-rpc-cosmos v1.1.3
 	github.com/cosmos/cosmos-sdk v0.46.16
 	github.com/cosmos/ibc-go/v6 v6.2.1
 	github.com/dymensionxyz/dymension-rdk v1.6.0

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.22.2
 
 require (
 	cosmossdk.io/errors v1.0.1
-	github.com/bcdevtools/block-explorer-rpc-cosmos v1.1.4
+	github.com/bcdevtools/block-explorer-rpc-cosmos v1.1.6
 	github.com/bcdevtools/evm-block-explorer-rpc-cosmos v1.1.2
 	github.com/cosmos/cosmos-sdk v0.46.16
 	github.com/cosmos/ibc-go/v6 v6.2.1

--- a/go.sum
+++ b/go.sum
@@ -295,8 +295,8 @@ github.com/aws/aws-sdk-go-v2/service/route53 v1.1.1/go.mod h1:rLiOUrPLW/Er5kRcQ7
 github.com/aws/aws-sdk-go-v2/service/sso v1.1.1/go.mod h1:SuZJxklHxLAXgLTc1iFXbEWkXs7QRTQpCLGaKIprQW0=
 github.com/aws/aws-sdk-go-v2/service/sts v1.1.1/go.mod h1:Wi0EBZwiz/K44YliU0EKxqTCJGUfYTWXrrBwkq736bM=
 github.com/aws/smithy-go v1.1.0/go.mod h1:EzMw8dbp/YJL4A5/sbhGddag+NPT7q084agLbB9LgIw=
-github.com/bcdevtools/block-explorer-rpc-cosmos v1.1.4 h1:RvGu0kR6VTImQYF0bhjWcyJltDFj/gg9tjCln2++sgo=
-github.com/bcdevtools/block-explorer-rpc-cosmos v1.1.4/go.mod h1:AWXHI5ICXK4wB+A59dNddzq5Xdc1wtQDRiIXfMw8cwc=
+github.com/bcdevtools/block-explorer-rpc-cosmos v1.1.6 h1:vdw/IGzxeCjSsrFXZ10MvM4UL5WyepK1hyAcvx2dm78=
+github.com/bcdevtools/block-explorer-rpc-cosmos v1.1.6/go.mod h1:AWXHI5ICXK4wB+A59dNddzq5Xdc1wtQDRiIXfMw8cwc=
 github.com/bcdevtools/evm-block-explorer-rpc-cosmos v1.1.2 h1:EOsjOIaqlqgIz1V2zpIf4Av2OkPZsbGY2WQbhFTorr0=
 github.com/bcdevtools/evm-block-explorer-rpc-cosmos v1.1.2/go.mod h1:krYTATKzetOs629qD/rHKaBxRc4eDmNgI9KmrEv5aXQ=
 github.com/benbjohnson/clock v1.1.0/go.mod h1:J11/hYXuz8f4ySSvYwY0FKfm+ezbsZBKZxNJlLklBHA=

--- a/go.sum
+++ b/go.sum
@@ -295,8 +295,8 @@ github.com/aws/aws-sdk-go-v2/service/route53 v1.1.1/go.mod h1:rLiOUrPLW/Er5kRcQ7
 github.com/aws/aws-sdk-go-v2/service/sso v1.1.1/go.mod h1:SuZJxklHxLAXgLTc1iFXbEWkXs7QRTQpCLGaKIprQW0=
 github.com/aws/aws-sdk-go-v2/service/sts v1.1.1/go.mod h1:Wi0EBZwiz/K44YliU0EKxqTCJGUfYTWXrrBwkq736bM=
 github.com/aws/smithy-go v1.1.0/go.mod h1:EzMw8dbp/YJL4A5/sbhGddag+NPT7q084agLbB9LgIw=
-github.com/bcdevtools/block-explorer-rpc-cosmos v1.2.2 h1:/FRrJTDPr1CEDxkR58xnVd4FBJVetfeG+R9G4/EnXYI=
-github.com/bcdevtools/block-explorer-rpc-cosmos v1.2.2/go.mod h1:AWXHI5ICXK4wB+A59dNddzq5Xdc1wtQDRiIXfMw8cwc=
+github.com/bcdevtools/block-explorer-rpc-cosmos v1.2.3 h1:nF9aC1/fTW4hb/DWO+/D4+FWD+NIh1QHp7sVjzWdJZY=
+github.com/bcdevtools/block-explorer-rpc-cosmos v1.2.3/go.mod h1:AWXHI5ICXK4wB+A59dNddzq5Xdc1wtQDRiIXfMw8cwc=
 github.com/bcdevtools/evm-block-explorer-rpc-cosmos v1.1.3 h1:j/tzqUrYOL+Uwopfl4p56nHhoIzHSldTP8VLqzhmuus=
 github.com/bcdevtools/evm-block-explorer-rpc-cosmos v1.1.3/go.mod h1:OFU5T7Zc38gC45ZxBwX9lQT997G553lj++j6SQTipcE=
 github.com/benbjohnson/clock v1.1.0/go.mod h1:J11/hYXuz8f4ySSvYwY0FKfm+ezbsZBKZxNJlLklBHA=

--- a/go.sum
+++ b/go.sum
@@ -297,8 +297,8 @@ github.com/aws/aws-sdk-go-v2/service/sts v1.1.1/go.mod h1:Wi0EBZwiz/K44YliU0EKxq
 github.com/aws/smithy-go v1.1.0/go.mod h1:EzMw8dbp/YJL4A5/sbhGddag+NPT7q084agLbB9LgIw=
 github.com/bcdevtools/block-explorer-rpc-cosmos v1.1.7 h1:iKBQH4glCNzuXwjsEya893r3c41SYxOoJKamob9nZdQ=
 github.com/bcdevtools/block-explorer-rpc-cosmos v1.1.7/go.mod h1:AWXHI5ICXK4wB+A59dNddzq5Xdc1wtQDRiIXfMw8cwc=
-github.com/bcdevtools/evm-block-explorer-rpc-cosmos v1.1.2 h1:EOsjOIaqlqgIz1V2zpIf4Av2OkPZsbGY2WQbhFTorr0=
-github.com/bcdevtools/evm-block-explorer-rpc-cosmos v1.1.2/go.mod h1:krYTATKzetOs629qD/rHKaBxRc4eDmNgI9KmrEv5aXQ=
+github.com/bcdevtools/evm-block-explorer-rpc-cosmos v1.1.3 h1:j/tzqUrYOL+Uwopfl4p56nHhoIzHSldTP8VLqzhmuus=
+github.com/bcdevtools/evm-block-explorer-rpc-cosmos v1.1.3/go.mod h1:OFU5T7Zc38gC45ZxBwX9lQT997G553lj++j6SQTipcE=
 github.com/benbjohnson/clock v1.1.0/go.mod h1:J11/hYXuz8f4ySSvYwY0FKfm+ezbsZBKZxNJlLklBHA=
 github.com/benbjohnson/clock v1.3.0/go.mod h1:J11/hYXuz8f4ySSvYwY0FKfm+ezbsZBKZxNJlLklBHA=
 github.com/benbjohnson/clock v1.3.5 h1:VvXlSJBzZpA/zum6Sj74hxwYI2DIxRWuNIoXAzHZz5o=

--- a/go.sum
+++ b/go.sum
@@ -295,8 +295,8 @@ github.com/aws/aws-sdk-go-v2/service/route53 v1.1.1/go.mod h1:rLiOUrPLW/Er5kRcQ7
 github.com/aws/aws-sdk-go-v2/service/sso v1.1.1/go.mod h1:SuZJxklHxLAXgLTc1iFXbEWkXs7QRTQpCLGaKIprQW0=
 github.com/aws/aws-sdk-go-v2/service/sts v1.1.1/go.mod h1:Wi0EBZwiz/K44YliU0EKxqTCJGUfYTWXrrBwkq736bM=
 github.com/aws/smithy-go v1.1.0/go.mod h1:EzMw8dbp/YJL4A5/sbhGddag+NPT7q084agLbB9LgIw=
-github.com/bcdevtools/block-explorer-rpc-cosmos v1.2.1 h1:09LzkTjZZPUa0e0U8SM0gSPETdoNiyLNLYLZCkLDbBE=
-github.com/bcdevtools/block-explorer-rpc-cosmos v1.2.1/go.mod h1:AWXHI5ICXK4wB+A59dNddzq5Xdc1wtQDRiIXfMw8cwc=
+github.com/bcdevtools/block-explorer-rpc-cosmos v1.2.2 h1:/FRrJTDPr1CEDxkR58xnVd4FBJVetfeG+R9G4/EnXYI=
+github.com/bcdevtools/block-explorer-rpc-cosmos v1.2.2/go.mod h1:AWXHI5ICXK4wB+A59dNddzq5Xdc1wtQDRiIXfMw8cwc=
 github.com/bcdevtools/evm-block-explorer-rpc-cosmos v1.1.3 h1:j/tzqUrYOL+Uwopfl4p56nHhoIzHSldTP8VLqzhmuus=
 github.com/bcdevtools/evm-block-explorer-rpc-cosmos v1.1.3/go.mod h1:OFU5T7Zc38gC45ZxBwX9lQT997G553lj++j6SQTipcE=
 github.com/benbjohnson/clock v1.1.0/go.mod h1:J11/hYXuz8f4ySSvYwY0FKfm+ezbsZBKZxNJlLklBHA=

--- a/go.sum
+++ b/go.sum
@@ -295,8 +295,8 @@ github.com/aws/aws-sdk-go-v2/service/route53 v1.1.1/go.mod h1:rLiOUrPLW/Er5kRcQ7
 github.com/aws/aws-sdk-go-v2/service/sso v1.1.1/go.mod h1:SuZJxklHxLAXgLTc1iFXbEWkXs7QRTQpCLGaKIprQW0=
 github.com/aws/aws-sdk-go-v2/service/sts v1.1.1/go.mod h1:Wi0EBZwiz/K44YliU0EKxqTCJGUfYTWXrrBwkq736bM=
 github.com/aws/smithy-go v1.1.0/go.mod h1:EzMw8dbp/YJL4A5/sbhGddag+NPT7q084agLbB9LgIw=
-github.com/bcdevtools/block-explorer-rpc-cosmos v1.1.7 h1:iKBQH4glCNzuXwjsEya893r3c41SYxOoJKamob9nZdQ=
-github.com/bcdevtools/block-explorer-rpc-cosmos v1.1.7/go.mod h1:AWXHI5ICXK4wB+A59dNddzq5Xdc1wtQDRiIXfMw8cwc=
+github.com/bcdevtools/block-explorer-rpc-cosmos v1.2.1 h1:09LzkTjZZPUa0e0U8SM0gSPETdoNiyLNLYLZCkLDbBE=
+github.com/bcdevtools/block-explorer-rpc-cosmos v1.2.1/go.mod h1:AWXHI5ICXK4wB+A59dNddzq5Xdc1wtQDRiIXfMw8cwc=
 github.com/bcdevtools/evm-block-explorer-rpc-cosmos v1.1.3 h1:j/tzqUrYOL+Uwopfl4p56nHhoIzHSldTP8VLqzhmuus=
 github.com/bcdevtools/evm-block-explorer-rpc-cosmos v1.1.3/go.mod h1:OFU5T7Zc38gC45ZxBwX9lQT997G553lj++j6SQTipcE=
 github.com/benbjohnson/clock v1.1.0/go.mod h1:J11/hYXuz8f4ySSvYwY0FKfm+ezbsZBKZxNJlLklBHA=

--- a/go.sum
+++ b/go.sum
@@ -295,8 +295,8 @@ github.com/aws/aws-sdk-go-v2/service/route53 v1.1.1/go.mod h1:rLiOUrPLW/Er5kRcQ7
 github.com/aws/aws-sdk-go-v2/service/sso v1.1.1/go.mod h1:SuZJxklHxLAXgLTc1iFXbEWkXs7QRTQpCLGaKIprQW0=
 github.com/aws/aws-sdk-go-v2/service/sts v1.1.1/go.mod h1:Wi0EBZwiz/K44YliU0EKxqTCJGUfYTWXrrBwkq736bM=
 github.com/aws/smithy-go v1.1.0/go.mod h1:EzMw8dbp/YJL4A5/sbhGddag+NPT7q084agLbB9LgIw=
-github.com/bcdevtools/block-explorer-rpc-cosmos v1.1.6 h1:vdw/IGzxeCjSsrFXZ10MvM4UL5WyepK1hyAcvx2dm78=
-github.com/bcdevtools/block-explorer-rpc-cosmos v1.1.6/go.mod h1:AWXHI5ICXK4wB+A59dNddzq5Xdc1wtQDRiIXfMw8cwc=
+github.com/bcdevtools/block-explorer-rpc-cosmos v1.1.7 h1:iKBQH4glCNzuXwjsEya893r3c41SYxOoJKamob9nZdQ=
+github.com/bcdevtools/block-explorer-rpc-cosmos v1.1.7/go.mod h1:AWXHI5ICXK4wB+A59dNddzq5Xdc1wtQDRiIXfMw8cwc=
 github.com/bcdevtools/evm-block-explorer-rpc-cosmos v1.1.2 h1:EOsjOIaqlqgIz1V2zpIf4Av2OkPZsbGY2WQbhFTorr0=
 github.com/bcdevtools/evm-block-explorer-rpc-cosmos v1.1.2/go.mod h1:krYTATKzetOs629qD/rHKaBxRc4eDmNgI9KmrEv5aXQ=
 github.com/benbjohnson/clock v1.1.0/go.mod h1:J11/hYXuz8f4ySSvYwY0FKfm+ezbsZBKZxNJlLklBHA=


### PR DESCRIPTION
This update contains
- Fix a RPC crash
- Improve block details content
- Improve validator list content
- Fix + Add query module params for some modules
- Introduce new API `be_getRecentBlocks` for performance + some UX improvement reason

https://github.com/bcdevtools/block-explorer-rpc-cosmos/compare/v1.1.4...v1.2.3
https://github.com/bcdevtools/evm-block-explorer-rpc-cosmos/compare/v1.1.2...v1.1.3