### PR TITLE
Chore(readme): update instruction for running rly v0.3.3-v2.5.2-relayer

### DIFF
--- a/README.md
+++ b/README.md
@@ -202,7 +202,7 @@ rollapp-evm start
 ### Install dymension relayer
 
 ```shell
-git clone https://github.com/dymensionxyz/go-relayer.git --branch v0.3.0-v2.5.2-relayer
+git clone https://github.com/dymensionxyz/go-relayer.git --branch v0.3.1-v2.5.2-relayer
 cd go-relayer && make install
 ```
 
@@ -216,6 +216,16 @@ sh scripts/ibc/setup_ibc.sh
 ```
 
 After successful run, the new established channels will be shown
+
+### Set channel-filter
+
+After successful run, set channel-filter for flush to work properly, e.g:
+
+```shell
+src-channel-filter:
+      rule: \"allowlist\"
+      channel-list: [\"channel-0\", \"channel-49\"]
+```
 
 ### Configure empty block time to 1hr
 

--- a/README.md
+++ b/README.md
@@ -217,16 +217,6 @@ sh scripts/ibc/setup_ibc.sh
 
 After successful run, the new established channels will be shown
 
-### Set channel-filter
-
-After successful run, set channel-filter for flush to work properly, e.g:
-
-```shell
-src-channel-filter:
-      rule: "allowlist"
-      channel-list: ["channel-0", "channel-49"]
-```
-
 ### Configure empty block time to 1hr
 
 Stop the rollapp:

--- a/README.md
+++ b/README.md
@@ -223,8 +223,8 @@ After successful run, set channel-filter for flush to work properly, e.g:
 
 ```shell
 src-channel-filter:
-      rule: \"allowlist\"
-      channel-list: [\"channel-0\", \"channel-49\"]
+      rule: "allowlist"
+      channel-list: ["channel-0", "channel-49"]
 ```
 
 ### Configure empty block time to 1hr

--- a/README.md
+++ b/README.md
@@ -202,7 +202,7 @@ rollapp-evm start
 ### Install dymension relayer
 
 ```shell
-git clone https://github.com/dymensionxyz/go-relayer.git --branch v0.3.1-v2.5.2-relayer
+git clone https://github.com/dymensionxyz/go-relayer.git --branch v0.3.3-v2.5.2-relayer
 cd go-relayer && make install
 ```
 

--- a/scripts/ibc/setup_ibc.sh
+++ b/scripts/ibc/setup_ibc.sh
@@ -97,7 +97,7 @@ echo '--------------------------------- Creating IBC path... -------------------
 
 rly paths new "$ROLLAPP_CHAIN_ID" "$SETTLEMENT_CHAIN_ID" "$RELAYER_PATH" --src-port "$IBC_PORT" --dst-port "$IBC_PORT" --version "$IBC_VERSION"
 
-rly tx link "$RELAYER_PATH" --src-port "$IBC_PORT" --dst-port "$IBC_PORT" --version "$IBC_VERSION"
+rly tx link "$RELAYER_PATH" --src-port "$IBC_PORT" --dst-port "$IBC_PORT" --version "$IBC_VERSION" --max-clock-drift 70m
 # Channel is currently not created in the tx link since we changed the relayer to support on demand blocks
 # Which messed up with channel creation as part of tx link.
 rly tx channel "$RELAYER_PATH"

--- a/scripts/ibc/setup_ibc.sh
+++ b/scripts/ibc/setup_ibc.sh
@@ -104,18 +104,20 @@ rly tx channel "$RELAYER_PATH"
 
 echo '# -------------------------------- IBC channel established ------------------------------- #'
 echo "Channel Information:"
-echo "$(rly q channels "$ROLLAPP_CHAIN_ID" | jq '{ "rollapp-channel": .channel_id, "hub-channel": .counterparty.channel_id }')"
+
+channel_info=$(rly q channels "$ROLLAPP_CHAIN_ID" | jq '{ "rollapp-channel": .channel_id, "hub-channel": .counterparty.channel_id }')
+rollapp_channel=$(echo "$channel_info" | jq -r '.["rollapp-channel"]')
+hub_channel=$(echo "$channel_info" | jq -r '.["hub-channel"]')
+
+echo "$channel_info"
 
 echo -e '--------------------------------- Set channel-filter --------------------------------'
 
-read -p "Enter the first channel: " channel1
-read -p "Enter the second channel: " channel2
-
-if [ -z "$channel1" ] || [ -z "$channel2" ]; then
-  echo "Both channels must be provided. Exiting."
+if [ -z "$rollapp_channel" ] || [ -z "$hub_channel" ]; then
+  echo "Both channels must be provided. Something is wrong. Exiting."
   exit 1
 fi
 
 sed -i.bak '/rule:/s/.*/            rule: "allowlist"/' "$RLY_CONFIG_FILE"
-sed -i.bak '/channel-list:/s/.*/            channel-list: ["'"$channel1"'","'"$channel2"'"]/' "$RLY_CONFIG_FILE"
+sed -i.bak '/channel-list:/s/.*/            channel-list: ["'"$rollapp_channel"'","'"$hub_channel"'"]/' "$RLY_CONFIG_FILE"
 echo "Config file updated successfully."

--- a/scripts/ibc/setup_ibc.sh
+++ b/scripts/ibc/setup_ibc.sh
@@ -105,3 +105,17 @@ rly tx channel "$RELAYER_PATH"
 echo '# -------------------------------- IBC channel established ------------------------------- #'
 echo "Channel Information:"
 echo "$(rly q channels "$ROLLAPP_CHAIN_ID" | jq '{ "rollapp-channel": .channel_id, "hub-channel": .counterparty.channel_id }')"
+
+echo -e '--------------------------------- Set channel-filter --------------------------------'
+
+read -p "Enter the first channel: " channel1
+read -p "Enter the second channel: " channel2
+
+if [ -z "$channel1" ] || [ -z "$channel2" ]; then
+  echo "Both channels must be provided. Exiting."
+  exit 1
+fi
+
+sed -i.bak '/rule:/s/.*/            rule: "allowlist"/' "$RLY_CONFIG_FILE"
+sed -i.bak '/channel-list:/s/.*/            channel-list: ["'"$channel1"'","'"$channel2"'"]/' "$RLY_CONFIG_FILE"
+echo "Config file updated successfully."

--- a/scripts/ibc/setup_ibc.sh
+++ b/scripts/ibc/setup_ibc.sh
@@ -63,6 +63,9 @@ jq --arg rpc "$SETTLEMENT_RPC_FOR_RELAYER" '.value."rpc-addr" = $rpc' "$HUB_IBC_
 rly chains add --file "$ROLLAPP_IBC_CONF_FILE" "$ROLLAPP_CHAIN_ID"
 rly chains add --file "$HUB_IBC_CONF_FILE" "$SETTLEMENT_CHAIN_ID"
 
+echo -e '--------------------------------- Setting min-loop-duration to 100ms in rly config... --------------------------------'
+sed -i.bak '/min-loop-duration:/s/.*/            min-loop-duration: 100ms/' "$RLY_CONFIG_FILE"
+
 echo -e '--------------------------------- Creating keys for rly... --------------------------------'
 
 rly keys add "$ROLLAPP_CHAIN_ID" "$RELAYER_KEY_FOR_ROLLAP" --coin-type 60


### PR DESCRIPTION
## Description

Close #230 

PR review checkboxes:

I have...

- [ ]  Added a relevant changelog entry to the `Unreleased` section in `CHANGELOG.md`
- [ ]  Targeted PR against the correct branch
- [ ]  included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ]  Linked to the GitHub issue with discussion and accepted design
- [ ]  Targets only one GitHub issue
- [ ]  Wrote unit and integration tests
- [ ]  Wrote relevant migration scripts if necessary
- [ ]  All CI checks have passed
- [ ]  Added relevant `godoc` [comments](https://blog.golang.org/godoc-documenting-go-code)
- [ ]  Updated the scripts for local run, e.g genesis_config_commands.sh if the PR changes parameters
- [ ]  Add an issue in the [e2e-tests repo](https://github.com/dymensionxyz/e2e-tests) if necessary

SDK Checklist
- [ ] Import/Export Genesis
- [ ] Registered Invariants
- [ ] Registered Events
- [ ] Updated openapi.yaml
- [ ] No usage of go `map`
- [ ] No usage of `time.Now()`
- [ ] Used fixed point arithmetic and not float arithmetic
- [ ] Avoid panicking in Begin/End block as much as possible
- [ ] No unexpected math Overflow
- [ ] Used `sendCoin` and not `SendCoins`
- [ ] Out-of-block compute is bounded
- [ ] No serialized ID at the end of store keys
- [ ] UInt to byte conversion should use BigEndian

Full security checklist [here](https://www.faulttolerant.xyz/2024-01-16-cosmos-security-1/)


----;

For Reviewer:

- [ ]  Confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ]  Reviewers assigned
- [ ]  Confirmed all author checklist items have been addressed

---;

After reviewer approval:

- [ ]  In case the PR targets the main branch, PR should not be squash merge in order to keep meaningful git history.
- [ ]  In case the PR targets a release branch, PR must be rebased.
