### PR TITLE
Update genesis-mainnet.json unbonding time

### DIFF
--- a/genesis-templates/DRS/5/genesis-mainnet.json
+++ b/genesis-templates/DRS/5/genesis-mainnet.json
@@ -266,7 +266,7 @@
     },
     "sequencers": {
       "params": {
-        "unbonding_time": "1814400s",
+        "unbonding_time": "259200s",
         "historical_entries": 10000
       },
       "sequencers": []


### PR DESCRIPTION
This PR updates the unbonding time for DRS 5 to 3 days instead of 21 days.