### PR TITLE
Update genesis-mainnet.json min-commission

### DIFF
--- a/genesis-templates/DRS/5/genesis-mainnet.json
+++ b/genesis-templates/DRS/5/genesis-mainnet.json
@@ -278,7 +278,7 @@
         "max_entries": 7,
         "historical_entries": 10000,
         "bond_denom": "stake",
-        "min_commission_rate": "0.050000000000000000"
+        "min_commission_rate": "0.000000000000000000"
       },
       "last_total_power": "0",
       "last_validator_powers": [],


### PR DESCRIPTION
This PR updates the min-commission-rate of Governors to `0`. 