### PR TITLE
fix(ante): support gas free authz msgs

### DIFF
--- a/app/ante/ante.go
+++ b/app/ante/ante.go
@@ -8,6 +8,7 @@ import (
 	"github.com/cosmos/cosmos-sdk/client"
 	"github.com/cosmos/cosmos-sdk/codec"
 	codectypes "github.com/cosmos/cosmos-sdk/codec/types"
+	storetypes "github.com/cosmos/cosmos-sdk/store/types"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
 	authante "github.com/cosmos/cosmos-sdk/x/auth/ante"
@@ -44,6 +45,7 @@ func MustCreateHandler(codec codec.BinaryCodec,
 	feeGrantKeeper authante.FeegrantKeeper,
 	authzKeeper evmosanteevm.AuthzKeeper,
 	rollappparamsKeeper rollappparamskeeper.Keeper,
+	anteTransientStoreKey storetypes.StoreKey,
 ) sdk.AnteHandler {
 	ethOpts := evmosante.HandlerOptions{
 		Cdc:                codec,
@@ -64,13 +66,14 @@ func MustCreateHandler(codec codec.BinaryCodec,
 	}
 
 	opts := HandlerOptions{
-		HandlerOptions:      ethOpts,
-		hasPermission:       hasPermission,
-		DistrKeeper:         distrKeeper,
-		SequencersKeeper:    sequencerKeeper,
-		RollappParamsKeeper: rollappparamsKeeper,
-		BankKeeper:          bankKeeper,
-		ERC20Keeper:         erc20Keeper,
+		HandlerOptions:        ethOpts,
+		hasPermission:         hasPermission,
+		DistrKeeper:           distrKeeper,
+		SequencersKeeper:      sequencerKeeper,
+		RollappParamsKeeper:   rollappparamsKeeper,
+		BankKeeper:            bankKeeper,
+		ERC20Keeper:           erc20Keeper,
+		AnteTransientStoreKey: anteTransientStoreKey,
 	}
 
 	h, err := NewHandler(opts)
@@ -83,12 +86,13 @@ func MustCreateHandler(codec codec.BinaryCodec,
 // HandlerOptions are the options required for constructing a default SDK AnteHandler.
 type HandlerOptions struct {
 	evmosante.HandlerOptions
-	hasPermission       HasPermission
-	DistrKeeper         distrkeeper.Keeper
-	SequencersKeeper    seqkeeper.Keeper
-	RollappParamsKeeper rollappparamskeeper.Keeper
-	BankKeeper          bankkeeper.Keeper
-	ERC20Keeper         erc20keeper.Keeper
+	hasPermission         HasPermission
+	DistrKeeper           distrkeeper.Keeper
+	SequencersKeeper      seqkeeper.Keeper
+	RollappParamsKeeper   rollappparamskeeper.Keeper
+	BankKeeper            bankkeeper.Keeper
+	ERC20Keeper           erc20keeper.Keeper
+	AnteTransientStoreKey storetypes.StoreKey
 }
 
 func (o HandlerOptions) validate() error {

--- a/app/ante/create_account_decorator.go
+++ b/app/ante/create_account_decorator.go
@@ -10,6 +10,14 @@ import (
 	"github.com/cosmos/cosmos-sdk/x/auth/types"
 )
 
+const (
+	// MaxFreeAccountsPerBlock is the maximum number of free accounts that can be created per block
+	MaxFreeAccountsPerBlock = 10
+
+	// freeAccountCountKey is the key used to track the number of free accounts created in the current block
+	freeAccountCountKey = "free_account_count"
+)
+
 type CreateAccountDecorator struct {
 	ak                    accountKeeper
 	anteTransientStoreKey storetypes.StoreKey

--- a/app/ante/create_account_decorator_test.go
+++ b/app/ante/create_account_decorator_test.go
@@ -1,0 +1,487 @@
+package ante
+
+import (
+	"testing"
+
+	"github.com/cosmos/cosmos-sdk/crypto/keys/secp256k1"
+	cryptotypes "github.com/cosmos/cosmos-sdk/crypto/types"
+	"github.com/cosmos/cosmos-sdk/store"
+	storetypes "github.com/cosmos/cosmos-sdk/store/types"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/cosmos/cosmos-sdk/types/tx/signing"
+	"github.com/cosmos/cosmos-sdk/x/auth/types"
+	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
+	"github.com/cosmos/cosmos-sdk/x/authz"
+	"github.com/cosmos/cosmos-sdk/x/feegrant"
+	clienttypes "github.com/cosmos/ibc-go/v6/modules/core/02-client/types"
+	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/suite"
+	"github.com/tendermint/tendermint/libs/log"
+	tmproto "github.com/tendermint/tendermint/proto/tendermint/types"
+	dbm "github.com/tendermint/tm-db"
+)
+
+// Mock implementations
+type mockAccountKeeper struct {
+	accounts map[string]types.AccountI
+}
+
+func newMockAccountKeeper() *mockAccountKeeper {
+	return &mockAccountKeeper{
+		accounts: make(map[string]types.AccountI),
+	}
+}
+
+func (m *mockAccountKeeper) GetAccount(ctx sdk.Context, addr sdk.AccAddress) types.AccountI {
+	return m.accounts[addr.String()]
+}
+
+func (m *mockAccountKeeper) SetAccount(ctx sdk.Context, acc types.AccountI) {
+	m.accounts[acc.GetAddress().String()] = acc
+}
+
+func (m *mockAccountKeeper) NewAccountWithAddress(ctx sdk.Context, addr sdk.AccAddress) types.AccountI {
+	return authtypes.NewBaseAccountWithAddress(addr)
+}
+
+func (m *mockAccountKeeper) GetParams(ctx sdk.Context) types.Params {
+	return types.DefaultParams()
+}
+
+func (m *mockAccountKeeper) GetModuleAddress(moduleName string) sdk.AccAddress {
+	return sdk.AccAddress([]byte(moduleName))
+}
+
+// Mock transaction implementation
+type mockTx struct {
+	msgs    []sdk.Msg
+	signers []sdk.AccAddress
+	pubKeys []cryptotypes.PubKey
+}
+
+func (m mockTx) GetMsgs() []sdk.Msg {
+	return m.msgs
+}
+
+func (m mockTx) GetSigners() []sdk.AccAddress {
+	return m.signers
+}
+
+func (m mockTx) GetPubKeys() ([]cryptotypes.PubKey, error) {
+	return m.pubKeys, nil
+}
+
+func (m mockTx) GetSignaturesV2() ([]signing.SignatureV2, error) {
+	return nil, nil
+}
+
+func (m mockTx) ValidateBasic() error {
+	return nil
+}
+
+// Test suite
+type CreateAccountDecoratorTestSuite struct {
+	suite.Suite
+	ctx           sdk.Context
+	accountKeeper *mockAccountKeeper
+	decorator     CreateAccountDecorator
+	tStoreKey     storetypes.StoreKey
+}
+
+func TestCreateAccountDecoratorTestSuite(t *testing.T) {
+	suite.Run(t, new(CreateAccountDecoratorTestSuite))
+}
+
+func (suite *CreateAccountDecoratorTestSuite) SetupTest() {
+	// Create a minimal context with transient store
+	db := dbm.NewMemDB()
+	kvStoreKey := sdk.NewKVStoreKey("test")
+	suite.tStoreKey = storetypes.NewTransientStoreKey("ante_transient")
+
+	cms := store.NewCommitMultiStore(db)
+	cms.MountStoreWithDB(kvStoreKey, storetypes.StoreTypeIAVL, db)
+	cms.MountStoreWithDB(suite.tStoreKey, storetypes.StoreTypeTransient, db)
+	err := cms.LoadLatestVersion()
+	if err != nil {
+		panic(err)
+	}
+
+	suite.ctx = sdk.NewContext(cms, tmproto.Header{Height: 1}, false, log.NewNopLogger())
+	suite.accountKeeper = newMockAccountKeeper()
+	suite.decorator = NewCreateAccountDecorator(suite.accountKeeper, suite.tStoreKey)
+}
+
+// Helper to create a mock next handler
+func (suite *CreateAccountDecoratorTestSuite) mockNextHandler(called *bool) sdk.AnteHandler {
+	return func(ctx sdk.Context, tx sdk.Tx, simulate bool) (sdk.Context, error) {
+		*called = true
+		return ctx, nil
+	}
+}
+
+// Helper to create test address and pubkey
+func createTestAccount() (sdk.AccAddress, cryptotypes.PubKey) {
+	privKey := secp256k1.GenPrivKey()
+	pubKey := privKey.PubKey()
+	addr := sdk.AccAddress(pubKey.Address())
+	return addr, pubKey
+}
+
+// Test 1: Free account creation for IBC messages
+func (suite *CreateAccountDecoratorTestSuite) TestCreateAccountForIBCMessage() {
+	// Create a new account address that doesn't exist yet
+	privKey := secp256k1.GenPrivKey()
+	pubKey := privKey.PubKey()
+	newAddr := sdk.AccAddress(pubKey.Address())
+	require.Nil(suite.T(), suite.accountKeeper.GetAccount(suite.ctx, newAddr))
+
+	// Create an IBC message (client update)
+	ibcMsg := &clienttypes.MsgUpdateClient{
+		Signer: newAddr.String(),
+	}
+
+	tx := mockTx{
+		msgs:    []sdk.Msg{ibcMsg},
+		signers: []sdk.AccAddress{newAddr},
+		pubKeys: []cryptotypes.PubKey{pubKey},
+	}
+
+	nextCalled := false
+	_, err := suite.decorator.AnteHandle(suite.ctx, tx, false, suite.mockNextHandler(&nextCalled))
+
+	// Should succeed and create account
+	require.NoError(suite.T(), err)
+	require.True(suite.T(), nextCalled)
+
+	// Account should now exist
+	acc := suite.accountKeeper.GetAccount(suite.ctx, newAddr)
+	require.NotNil(suite.T(), acc)
+	require.Equal(suite.T(), newAddr.String(), acc.GetAddress().String())
+}
+
+// Test 2: Free account creation for authz.MsgGrant
+func (suite *CreateAccountDecoratorTestSuite) TestCreateAccountForAuthzMsgGrant() {
+	newAddr, pubKey := createTestAccount()
+	require.Nil(suite.T(), suite.accountKeeper.GetAccount(suite.ctx, newAddr))
+
+	granteeAddr, _ := createTestAccount()
+	authzMsg := &authz.MsgGrant{
+		Granter: newAddr.String(),
+		Grantee: granteeAddr.String(),
+	}
+
+	tx := mockTx{
+		msgs:    []sdk.Msg{authzMsg},
+		signers: []sdk.AccAddress{newAddr},
+		pubKeys: []cryptotypes.PubKey{pubKey},
+	}
+
+	nextCalled := false
+	_, err := suite.decorator.AnteHandle(suite.ctx, tx, false, suite.mockNextHandler(&nextCalled))
+
+	require.NoError(suite.T(), err)
+	require.True(suite.T(), nextCalled)
+
+	acc := suite.accountKeeper.GetAccount(suite.ctx, newAddr)
+	require.NotNil(suite.T(), acc)
+}
+
+// Test 3: Free account creation for feegrant.MsgGrantAllowance
+func (suite *CreateAccountDecoratorTestSuite) TestCreateAccountForFeegrantMsgGrantAllowance() {
+	newAddr, pubKey := createTestAccount()
+	require.Nil(suite.T(), suite.accountKeeper.GetAccount(suite.ctx, newAddr))
+
+	granteeAddr, _ := createTestAccount()
+	feegrantMsg := &feegrant.MsgGrantAllowance{
+		Granter: newAddr.String(),
+		Grantee: granteeAddr.String(),
+	}
+
+	tx := mockTx{
+		msgs:    []sdk.Msg{feegrantMsg},
+		signers: []sdk.AccAddress{newAddr},
+		pubKeys: []cryptotypes.PubKey{pubKey},
+	}
+
+	nextCalled := false
+	_, err := suite.decorator.AnteHandle(suite.ctx, tx, false, suite.mockNextHandler(&nextCalled))
+
+	require.NoError(suite.T(), err)
+	require.True(suite.T(), nextCalled)
+
+	acc := suite.accountKeeper.GetAccount(suite.ctx, newAddr)
+	require.NotNil(suite.T(), acc)
+}
+
+// Test 4: Account exists - should not create new account
+func (suite *CreateAccountDecoratorTestSuite) TestExistingAccountNotRecreated() {
+	existingAddr, pubKey := createTestAccount()
+	existingAcc := suite.accountKeeper.NewAccountWithAddress(suite.ctx, existingAddr)
+	suite.accountKeeper.SetAccount(suite.ctx, existingAcc)
+
+	ibcMsg := &clienttypes.MsgUpdateClient{
+		Signer: existingAddr.String(),
+	}
+
+	tx := mockTx{
+		msgs:    []sdk.Msg{ibcMsg},
+		signers: []sdk.AccAddress{existingAddr},
+		pubKeys: []cryptotypes.PubKey{pubKey},
+	}
+
+	nextCalled := false
+	_, err := suite.decorator.AnteHandle(suite.ctx, tx, false, suite.mockNextHandler(&nextCalled))
+
+	require.NoError(suite.T(), err)
+	require.True(suite.T(), nextCalled)
+}
+
+// Test 5: Rate limiting - exceeding max accounts per block
+func (suite *CreateAccountDecoratorTestSuite) TestRateLimitingExceedsMax() {
+	// Create MaxFreeAccountsPerBlock accounts successfully
+	for i := 0; i < int(MaxFreeAccountsPerBlock); i++ {
+		addr, pubKey := createTestAccount()
+
+		ibcMsg := &clienttypes.MsgUpdateClient{
+			Signer: addr.String(),
+		}
+
+		tx := mockTx{
+			msgs:    []sdk.Msg{ibcMsg},
+			signers: []sdk.AccAddress{addr},
+			pubKeys: []cryptotypes.PubKey{pubKey},
+		}
+
+		nextCalled := false
+		_, err := suite.decorator.AnteHandle(suite.ctx, tx, false, suite.mockNextHandler(&nextCalled))
+
+		require.NoError(suite.T(), err, "Account %d should succeed", i)
+		require.True(suite.T(), nextCalled)
+
+		acc := suite.accountKeeper.GetAccount(suite.ctx, addr)
+		require.NotNil(suite.T(), acc)
+	}
+
+	// The next account creation should fail due to rate limit
+	overLimitAddr, overLimitPubKey := createTestAccount()
+
+	ibcMsg := &clienttypes.MsgUpdateClient{
+		Signer: overLimitAddr.String(),
+	}
+
+	tx := mockTx{
+		msgs:    []sdk.Msg{ibcMsg},
+		signers: []sdk.AccAddress{overLimitAddr},
+		pubKeys: []cryptotypes.PubKey{overLimitPubKey},
+	}
+
+	nextCalled := false
+	_, err := suite.decorator.AnteHandle(suite.ctx, tx, false, suite.mockNextHandler(&nextCalled))
+
+	require.Error(suite.T(), err)
+	require.Contains(suite.T(), err.Error(), "exceeded maximum free account creations per block")
+	require.False(suite.T(), nextCalled)
+
+	// Account should NOT have been created
+	acc := suite.accountKeeper.GetAccount(suite.ctx, overLimitAddr)
+	require.Nil(suite.T(), acc)
+}
+
+// Test 6: Cross-block rate limiting - counter resets for new block
+func (suite *CreateAccountDecoratorTestSuite) TestRateLimitingResetsAcrossBlocks() {
+	// Block 1: Create MaxFreeAccountsPerBlock accounts
+	for i := 0; i < int(MaxFreeAccountsPerBlock); i++ {
+		addr, pubKey := createTestAccount()
+
+		ibcMsg := &clienttypes.MsgUpdateClient{
+			Signer: addr.String(),
+		}
+
+		tx := mockTx{
+			msgs:    []sdk.Msg{ibcMsg},
+			signers: []sdk.AccAddress{addr},
+			pubKeys: []cryptotypes.PubKey{pubKey},
+		}
+
+		nextCalled := false
+		_, err := suite.decorator.AnteHandle(suite.ctx, tx, false, suite.mockNextHandler(&nextCalled))
+		require.NoError(suite.T(), err)
+	}
+
+	// Verify we've hit the limit in block 1
+	overLimitAddr1, overLimitPubKey1 := createTestAccount()
+	tx1 := mockTx{
+		msgs:    []sdk.Msg{&clienttypes.MsgUpdateClient{Signer: overLimitAddr1.String()}},
+		signers: []sdk.AccAddress{overLimitAddr1},
+		pubKeys: []cryptotypes.PubKey{overLimitPubKey1},
+	}
+	_, err := suite.decorator.AnteHandle(suite.ctx, tx1, false, suite.mockNextHandler(new(bool)))
+	require.Error(suite.T(), err)
+	require.Contains(suite.T(), err.Error(), "exceeded maximum")
+
+	// Simulate a new block by creating a new context with a fresh transient store
+	// In real blockchain, transient store is automatically cleared between blocks
+	suite.SetupTest() // This recreates the context with a fresh transient store and increments height
+	suite.ctx = suite.ctx.WithBlockHeight(2)
+
+	// Block 2: Should be able to create MaxFreeAccountsPerBlock accounts again
+	for i := 0; i < int(MaxFreeAccountsPerBlock); i++ {
+		addr, pubKey := createTestAccount()
+
+		ibcMsg := &clienttypes.MsgUpdateClient{
+			Signer: addr.String(),
+		}
+
+		tx := mockTx{
+			msgs:    []sdk.Msg{ibcMsg},
+			signers: []sdk.AccAddress{addr},
+			pubKeys: []cryptotypes.PubKey{pubKey},
+		}
+
+		nextCalled := false
+		_, err := suite.decorator.AnteHandle(suite.ctx, tx, false, suite.mockNextHandler(&nextCalled))
+		require.NoError(suite.T(), err, "Block 2: Account %d should succeed (counter should reset)", i)
+	}
+
+	// Verify we hit the limit again in block 2
+	overLimitAddr2, overLimitPubKey2 := createTestAccount()
+	tx2 := mockTx{
+		msgs:    []sdk.Msg{&clienttypes.MsgUpdateClient{Signer: overLimitAddr2.String()}},
+		signers: []sdk.AccAddress{overLimitAddr2},
+		pubKeys: []cryptotypes.PubKey{overLimitPubKey2},
+	}
+	_, err = suite.decorator.AnteHandle(suite.ctx, tx2, false, suite.mockNextHandler(new(bool)))
+	require.Error(suite.T(), err)
+	require.Contains(suite.T(), err.Error(), "exceeded maximum")
+}
+
+// Test 7: Non-free message should fail if account doesn't exist
+func (suite *CreateAccountDecoratorTestSuite) TestNonFreeMessageFailsForNonExistentAccount() {
+	newAddr, pubKey := createTestAccount()
+	require.Nil(suite.T(), suite.accountKeeper.GetAccount(suite.ctx, newAddr))
+
+	// Use a non-free message type (e.g., MsgRevoke which is not in the free list)
+	authzRevokeMsg := &authz.MsgRevoke{
+		Granter: newAddr.String(),
+		Grantee: sdk.AccAddress([]byte("grantee123456789")).String(),
+	}
+
+	tx := mockTx{
+		msgs:    []sdk.Msg{authzRevokeMsg},
+		signers: []sdk.AccAddress{newAddr},
+		pubKeys: []cryptotypes.PubKey{pubKey},
+	}
+
+	nextCalled := false
+	_, err := suite.decorator.AnteHandle(suite.ctx, tx, false, suite.mockNextHandler(&nextCalled))
+
+	// Should fail because account doesn't exist and message is not free
+	require.Error(suite.T(), err)
+	require.False(suite.T(), nextCalled)
+
+	// Account should NOT have been created
+	acc := suite.accountKeeper.GetAccount(suite.ctx, newAddr)
+	require.Nil(suite.T(), acc)
+}
+
+// Test 8: Mixed messages (free + non-free) should not create account
+func (suite *CreateAccountDecoratorTestSuite) TestMixedMessagesDoNotCreateAccount() {
+	newAddr, pubKey := createTestAccount()
+	require.Nil(suite.T(), suite.accountKeeper.GetAccount(suite.ctx, newAddr))
+
+	// Mix authz.MsgGrant (free) with authz.MsgRevoke (non-free)
+	authzGrantMsg := &authz.MsgGrant{
+		Granter: newAddr.String(),
+		Grantee: sdk.AccAddress([]byte("grantee123456789")).String(),
+	}
+	authzRevokeMsg := &authz.MsgRevoke{
+		Granter: newAddr.String(),
+		Grantee: sdk.AccAddress([]byte("grantee123456789")).String(),
+	}
+
+	tx := mockTx{
+		msgs:    []sdk.Msg{authzGrantMsg, authzRevokeMsg},
+		signers: []sdk.AccAddress{newAddr, newAddr},
+		pubKeys: []cryptotypes.PubKey{pubKey, pubKey},
+	}
+
+	nextCalled := false
+	_, err := suite.decorator.AnteHandle(suite.ctx, tx, false, suite.mockNextHandler(&nextCalled))
+
+	// Should fail because not all messages are free
+	require.Error(suite.T(), err)
+	require.False(suite.T(), nextCalled)
+
+	acc := suite.accountKeeper.GetAccount(suite.ctx, newAddr)
+	require.Nil(suite.T(), acc)
+}
+
+// Test 9: Context value for new account is set correctly
+func (suite *CreateAccountDecoratorTestSuite) TestNewAccountContextValueSet() {
+	newAddr, pubKey := createTestAccount()
+
+	ibcMsg := &clienttypes.MsgUpdateClient{
+		Signer: newAddr.String(),
+	}
+
+	tx := mockTx{
+		msgs:    []sdk.Msg{ibcMsg},
+		signers: []sdk.AccAddress{newAddr},
+		pubKeys: []cryptotypes.PubKey{pubKey},
+	}
+
+	// Custom next handler that checks for context value
+	nextHandler := func(ctx sdk.Context, tx sdk.Tx, simulate bool) (sdk.Context, error) {
+		// Check that the context has the new account flag
+		_, isNewAcc := ctx.Value(CtxKeyNewAccount(newAddr.String())).(struct{})
+		require.True(suite.T(), isNewAcc, "New account flag should be set in context")
+		return ctx, nil
+	}
+
+	_, err := suite.decorator.AnteHandle(suite.ctx, tx, false, nextHandler)
+	require.NoError(suite.T(), err)
+}
+
+// Test 10: Rate limiting doesn't affect existing accounts
+func (suite *CreateAccountDecoratorTestSuite) TestRateLimitingDoesNotAffectExistingAccounts() {
+	// First, hit the rate limit
+	for i := 0; i < int(MaxFreeAccountsPerBlock); i++ {
+		addr, pubKey := createTestAccount()
+
+		ibcMsg := &clienttypes.MsgUpdateClient{
+			Signer: addr.String(),
+		}
+
+		tx := mockTx{
+			msgs:    []sdk.Msg{ibcMsg},
+			signers: []sdk.AccAddress{addr},
+			pubKeys: []cryptotypes.PubKey{pubKey},
+		}
+
+		_, err := suite.decorator.AnteHandle(suite.ctx, tx, false, suite.mockNextHandler(new(bool)))
+		require.NoError(suite.T(), err)
+	}
+
+	// Create an existing account
+	existingAddr, existingPubKey := createTestAccount()
+	existingAcc := suite.accountKeeper.NewAccountWithAddress(suite.ctx, existingAddr)
+	suite.accountKeeper.SetAccount(suite.ctx, existingAcc)
+
+	// Transaction from existing account should still work even though rate limit is hit
+	ibcMsg := &clienttypes.MsgUpdateClient{
+		Signer: existingAddr.String(),
+	}
+
+	tx := mockTx{
+		msgs:    []sdk.Msg{ibcMsg},
+		signers: []sdk.AccAddress{existingAddr},
+		pubKeys: []cryptotypes.PubKey{existingPubKey},
+	}
+
+	nextCalled := false
+	_, err := suite.decorator.AnteHandle(suite.ctx, tx, false, suite.mockNextHandler(&nextCalled))
+
+	// Should succeed because account already exists
+	require.NoError(suite.T(), err)
+	require.True(suite.T(), nextCalled)
+}

--- a/app/ante/handlers.go
+++ b/app/ante/handlers.go
@@ -78,7 +78,7 @@ func cosmosHandler(options HandlerOptions, sigChecker sdk.AnteDecorator) sdk.Ant
 			options.SequencersKeeper,
 			options.RollappParamsKeeper,
 		),
-		NewCreateAccountDecorator(options.AccountKeeper),
+		NewCreateAccountDecorator(options.AccountKeeper, options.AnteTransientStoreKey),
 		ante.NewConsumeGasForTxSizeDecorator(options.AccountKeeper),
 		rdkante.NewBypassIBCFeeDecorator(
 			cosmosante.NewDeductFeeDecorator(options.AccountKeeper, options.BankKeeper, options.ERC20Keeper, options.DistributionKeeper, options.FeegrantKeeper, options.StakingKeeper, options.TxFeeChecker),

--- a/app/ante/utils.go
+++ b/app/ante/utils.go
@@ -1,0 +1,41 @@
+package ante
+
+import (
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/cosmos/cosmos-sdk/x/authz"
+	"github.com/cosmos/cosmos-sdk/x/feegrant"
+	rdkante "github.com/dymensionxyz/dymension-rdk/server/ante"
+)
+
+// isFreeNonIBCMsg returns true for non-IBC messages that are allowed to bypass fees
+// unconditionally when they are the only messages in the transaction.
+func isFreeNonIBCMsg(m sdk.Msg) bool {
+	switch m.(type) {
+	case *authz.MsgGrant:
+		return true
+	case *feegrant.MsgGrantAllowance:
+		return true
+	default:
+		return false
+	}
+}
+
+// isFreeMsg returns true if the transaction contains only messages that should
+// be free and allow account creation without funds.
+// This includes both IBC-only messages and specific non-IBC messages like authz.MsgGrant
+// and feegrant.MsgGrantAllowance.
+func isFreeMsg(msgs ...sdk.Msg) bool {
+	// Check if it's IBC-only messages
+	if rdkante.IbcOnly(msgs...) {
+		return true
+	}
+
+	// Check if all messages are free non-IBC messages
+	for _, msg := range msgs {
+		if !isFreeNonIBCMsg(msg) {
+			return false
+		}
+	}
+
+	return true
+}

--- a/app/ante/utils.go
+++ b/app/ante/utils.go
@@ -7,16 +7,8 @@ import (
 	rdkante "github.com/dymensionxyz/dymension-rdk/server/ante"
 )
 
-const (
-	// TransientStoreKey is the transient store key for ante handler state
-	TransientStoreKey = "ante_transient"
-
-	// MaxFreeAccountsPerBlock is the maximum number of free accounts that can be created per block
-	MaxFreeAccountsPerBlock = 10
-
-	// freeAccountCountKey is the key used to track the number of free accounts created in the current block
-	freeAccountCountKey = "free_account_count"
-)
+// TransientStoreKey is the transient store key for ante handler state
+const TransientStoreKey = "ante_transient"
 
 // isFreeNonIBCMsg returns true for non-IBC messages that are allowed to bypass fees
 // unconditionally when they are the only messages in the transaction.

--- a/app/ante/utils.go
+++ b/app/ante/utils.go
@@ -7,6 +7,17 @@ import (
 	rdkante "github.com/dymensionxyz/dymension-rdk/server/ante"
 )
 
+const (
+	// TransientStoreKey is the transient store key for ante handler state
+	TransientStoreKey = "ante_transient"
+
+	// MaxFreeAccountsPerBlock is the maximum number of free accounts that can be created per block
+	MaxFreeAccountsPerBlock = 10
+
+	// freeAccountCountKey is the key used to track the number of free accounts created in the current block
+	freeAccountCountKey = "free_account_count"
+)
+
 // isFreeNonIBCMsg returns true for non-IBC messages that are allowed to bypass fees
 // unconditionally when they are the only messages in the transaction.
 func isFreeNonIBCMsg(m sdk.Msg) bool {

--- a/app/ante/utils.go
+++ b/app/ante/utils.go
@@ -36,6 +36,11 @@ func isFreeNonIBCMsg(m sdk.Msg) bool {
 // This includes both IBC-only messages and specific non-IBC messages like authz.MsgGrant
 // and feegrant.MsgGrantAllowance.
 func isFreeMsg(msgs ...sdk.Msg) bool {
+	// Empty messages should return false
+	if len(msgs) == 0 {
+		return false
+	}
+
 	// Check if it's IBC-only messages
 	if rdkante.IbcOnly(msgs...) {
 		return true

--- a/app/app.go
+++ b/app/app.go
@@ -395,7 +395,7 @@ func NewRollapp(
 	)
 
 	// Add the EVM transient store key
-	tkeys := sdk.NewTransientStoreKeys(paramstypes.TStoreKey, evmtypes.TransientKey, feemarkettypes.TransientKey)
+	tkeys := sdk.NewTransientStoreKeys(paramstypes.TStoreKey, evmtypes.TransientKey, feemarkettypes.TransientKey, ante.TransientStoreKey)
 	memKeys := sdk.NewMemoryStoreKeys(capabilitytypes.MemStoreKey)
 
 	// load state streaming if enabled
@@ -861,6 +861,7 @@ func NewRollapp(
 		app.FeeGrantKeeper,
 		app.AuthzKeeper,
 		app.RollappParamsKeeper,
+		app.tkeys[ante.TransientStoreKey],
 	)
 	app.SetAnteHandler(h)
 

--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,6 @@ require (
 	github.com/bcdevtools/evm-block-explorer-rpc-cosmos v1.1.4
 	github.com/cosmos/cosmos-sdk v0.46.16
 	github.com/cosmos/ibc-go/v6 v6.2.1
-	github.com/dymensionxyz/cosmosclient v0.4.2-beta.0.20241121093220-e0d7ad456fbd
 	github.com/dymensionxyz/dymension-rdk v1.10.0-rc01.0.20250918164737-9ce090119185
 	github.com/dymensionxyz/dymint v1.6.0-rc01
 	github.com/ethereum/go-ethereum v1.12.0
@@ -125,6 +124,7 @@ require (
 	github.com/dop251/goja v0.0.0-20230806174421-c933cf95e127 // indirect
 	github.com/dustin/go-humanize v1.0.1 // indirect
 	github.com/dvsekhvalnov/jose2go v1.5.0 // indirect
+	github.com/dymensionxyz/cosmosclient v0.4.2-beta.0.20241121093220-e0d7ad456fbd // indirect
 	github.com/dymensionxyz/gerr-cosmos v1.0.0 // indirect
 	github.com/dymensionxyz/go-ethereum v0.0.0-20250326232313-18b28aa27ff2 // indirect
 	github.com/dymensionxyz/sdk-utils v0.1.2-0.20240909101947-e1b483ada9c8 // indirect

--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/cosmos/cosmos-sdk v0.46.16
 	github.com/cosmos/ibc-go/v6 v6.2.1
 	github.com/dymensionxyz/dymension-rdk v1.10.0-rc01.0.20250918164737-9ce090119185
-	github.com/dymensionxyz/dymint v1.6.0-rc01
+	github.com/dymensionxyz/dymint v1.6.0-rc02.0.20251023114832-97fea848df14
 	github.com/ethereum/go-ethereum v1.12.0
 	github.com/evmos/evmos/v12 v12.1.6
 	github.com/gogo/protobuf v1.3.3

--- a/go.sum
+++ b/go.sum
@@ -600,8 +600,8 @@ github.com/dymensionxyz/cosmosclient v0.4.2-beta.0.20241121093220-e0d7ad456fbd h
 github.com/dymensionxyz/cosmosclient v0.4.2-beta.0.20241121093220-e0d7ad456fbd/go.mod h1:3weqpVj/TqTFpC0LjEB3H+HZSpm7BrQ1QkEg1Ahy6KY=
 github.com/dymensionxyz/dymension-rdk v1.10.0-rc01.0.20250918164737-9ce090119185 h1:NxJE6da8vfyd3I4y49N2SwPwfacJibEY/eEcx2R0CMU=
 github.com/dymensionxyz/dymension-rdk v1.10.0-rc01.0.20250918164737-9ce090119185/go.mod h1:ppUiKmZWzYuaE4Hmhc4lW9uAT7Lta4PYQac3jlDtuqo=
-github.com/dymensionxyz/dymint v1.6.0-rc01 h1:GLLVKR6EL51Va/0nCRgKjqjLcUiitvCrXXDD103paZI=
-github.com/dymensionxyz/dymint v1.6.0-rc01/go.mod h1:Zh/ky1hHHs1dxTGPzsHM+laLriXvhthYEOPuFzP2hls=
+github.com/dymensionxyz/dymint v1.6.0-rc02.0.20251023114832-97fea848df14 h1:gP7IbeTwXHSGmMrihaWHoLPrN1H9yOCb3BXyQfxHmiY=
+github.com/dymensionxyz/dymint v1.6.0-rc02.0.20251023114832-97fea848df14/go.mod h1:egFViAvdBJxCdHP/L5AyU1GHnLL7zP5obnT7It8RVO4=
 github.com/dymensionxyz/evmos/v12 v12.1.7-0.20250914060644-204f1a342cd0 h1:Swwr6CluxSL0nbBkGm7qX50TUAcDua7QeVuSoOSZfHM=
 github.com/dymensionxyz/evmos/v12 v12.1.7-0.20250914060644-204f1a342cd0/go.mod h1:CI6D89pkoiIm4BjoMFNnEaCLdKBEobLuwvhS0c1zh7Y=
 github.com/dymensionxyz/gerr-cosmos v1.0.0 h1:oi91rgOkpJWr41oX9JOyjvvBnhGY54tj513x8VlDAEc=


### PR DESCRIPTION
while the RDK gas price ante handler allows "free" authz msgs,
we need to support `authz` msgs from non-existing account

* we create new account if needed for authz msg
* to mitigate DoS, by freely creating accounts, we added per-block rate limiting
(implemented by transient (perblock) store)